### PR TITLE
feat: drop egi-appliances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*-secret.yaml
+*-plainsecret.yaml

--- a/apps/dev-beskar/05-egi-eu/05-egi-eu.base/kustomization.yaml
+++ b/apps/dev-beskar/05-egi-eu/05-egi-eu.base/kustomization.yaml
@@ -5,4 +5,3 @@ resources:
   - 00-common-configmap.yaml
   - 00-common-encryptedsecret.yaml
   - 01-egi-accounting.yaml
-  #- 02-egi-appliances.yaml


### PR DESCRIPTION
This PR introduces:
 * drops egi-appliances (cloudkeeper) as is deprecated
 * adds gitignore to avoid commiting plan k8s secrets